### PR TITLE
docs(code-guidelines): add 'Prefer properties over setAttribute' JS rule (#53)

### DIFF
--- a/code-guidelines.md
+++ b/code-guidelines.md
@@ -665,7 +665,7 @@ When a boolean expression is complex, extract it into a named variable or functi
 
 ### Template and cloneNode
 
-When creating multiple similar elements in a loop, build one template element outside the loop with shared attributes and classes, then `cloneNode(false)` inside the loop and set only the per-instance values. Avoids redundant `createElement` / `setAttribute` / `classList.add` calls per iteration.
+When creating multiple similar elements in a loop, build one template element outside the loop with shared attributes and classes, then `cloneNode(false)` inside the loop and set only the per-instance values. Avoids redundant `createElement` / `setAttribute` / `classList.add` calls per iteration. Per-instance assignment should follow [Prefer properties over `setAttribute`](#javascript-1) — set typed properties directly and batch with `Object.assign`, falling back to `setAttribute` only for SVG / custom / unreflected ARIA attributes.
 
 ---
 
@@ -828,6 +828,55 @@ Semantic and behavioral rules. Where these overlap with the baseline authorities
   ).join("");
   ```
 - **Regular expressions.** Prefer simple patterns. Anchor where needed to avoid false matches. Test success and failure cases.
+- **Prefer properties over `setAttribute`.** Set DOM state through properties, not `setAttribute`. Properties take typed values directly — `disabled = true` instead of `setAttribute("disabled", "")`, `tabIndex = -1` instead of `setAttribute("tabindex", "-1")`. `setAttribute` is the fallback only when no property exists: custom attributes, most SVG attributes, and ARIA attributes whose property form is not in the supported browser baseline. For `data-*` set with a static name, use `dataset`; use `setAttribute` only when the data name is computed.
+
+  For multiple values on the same element, use `Object.assign`.
+
+  ❌ `setAttribute` per-property:
+  ```javascript
+  el.setAttribute("id", "save");
+  el.setAttribute("class", "btn primary");
+  el.setAttribute("disabled", "");
+  el.textContent = "Save";
+  el.setAttribute("data-action", "save");
+  ```
+
+  ✅ Properties + `Object.assign` + `dataset`:
+  ```javascript
+  Object.assign(el, {
+    id: "save",
+    className: "btn primary",
+    textContent: "Save",
+    disabled: true,
+  });
+  el.dataset.action = "save";
+  ```
+
+  When `setAttribute` is the right tool (SVG attributes, custom attributes) and multiple values are going on the same element, batch them via `Object.entries` instead of repeating the call:
+
+  ❌ Repeated `setAttribute`:
+  ```javascript
+  markerEl.setAttribute("id", markerId);
+  markerEl.setAttribute("markerWidth", "8");
+  markerEl.setAttribute("markerHeight", "6");
+  markerEl.setAttribute("refX", "8");
+  markerEl.setAttribute("refY", "3");
+  markerEl.setAttribute("orient", "auto");
+  ```
+
+  ✅ Property where it exists, `Object.entries` for the rest:
+  ```javascript
+  markerEl.id = markerId;
+  Object.entries({
+    markerWidth: "8",
+    markerHeight: "6",
+    refX: "8",
+    refY: "3",
+    orient: "auto",
+  }).forEach(([k, v]) => markerEl.setAttribute(k, v));
+  ```
+
+  This rule pairs with [Template and cloneNode](#template-and-clonenode): the per-instance assignment site after `cloneNode(false)` is exactly where the property-vs-`setAttribute` choice matters most.
 
 ---
 


### PR DESCRIPTION
Closes #53.

## What

Adds a **Language Rules → JavaScript** entry stating the
property-first preference for DOM state, immediately after the
existing **Regular expressions** bullet so it sits with the other
JavaScript language rules.

The new bullet:

- States the property-first preference (`disabled = true` over
  `setAttribute("disabled", "")`, `tabIndex = -1` over
  `setAttribute("tabindex", "-1")`).
- Lists the explicit exceptions: custom attributes with no property
  form, most SVG attributes, ARIA attributes whose property form is
  not in the supported browser baseline, and computed `data-*`
  names (static `data-*` goes through `dataset`).
- Includes the canonical `Object.assign` example for multi-property
  assignment in the property branch.
- Includes the `Object.entries` batching example for the
  `setAttribute` exception case (the SVG `<marker>` snippet from
  the issue).

## Cross-link

The Patterns → **Template and cloneNode** bullet now points at the
new rule, since the per-instance assignment site after
`cloneNode(false)` is exactly where the property-vs-`setAttribute`
choice matters most. The cross-link uses the section's own
GitHub-rendered anchor (`#javascript-1` — the second
`### JavaScript` heading on the page).

## Acceptance criteria

- [x] New entry added under Language Rules → JavaScript.
- [x] Rule states the property-first preference and names the
      exceptions (custom attributes, SVG, unreflected ARIA, computed
      data names).
- [x] Includes the `Object.assign` form for multi-property
      assignment.
- [x] Includes the `Object.entries` batching form for the
      `setAttribute` exception case.
- [x] Cross-linked from Template and cloneNode.