### PR TITLE
fix(web-xp-on): use current name in usage message

### DIFF
--- a/bin/web-xp-on
+++ b/bin/web-xp-on
@@ -10,7 +10,7 @@ END_MARKER='<!-- END WEB-XP -->'
 
 usage() {
   cat <<'EOF'
-Usage: web-xp-init [--preview] [claude|codex|all]
+Usage: web-xp-on [--preview] [claude|codex|all]
 
 Bootstrap Web XP project contracts in the current directory.
 


### PR DESCRIPTION
Closes #64.

`bin/web-xp-on` line 13 still printed `Usage: web-xp-init` after the rename in #24. Updated to `web-xp-on`.

Before:
```
$ bin/web-xp-on --help
Usage: web-xp-init [--preview] [claude|codex|all]
```

After:
```
$ bin/web-xp-on --help
Usage: web-xp-on [--preview] [claude|codex|all]
```