### PR TITLE
Publish and wire the Editorial Rules (ER)

### DIFF
--- a/adapters/claude/CLAUDE.example.md
+++ b/adapters/claude/CLAUDE.example.md
@@ -12,10 +12,15 @@ If the task involves JS, HTML, or CSS, read `code-guidelines.md` and `code-philo
 
 Apply the standard to the new code you write for the user's request. Do not refactor unrelated existing code unless the user asks. If you notice pre-existing Web XP violations outside the requested scope, ask whether to fix them now, list them, or leave them.
 
+## Editorial Rules (ER)
+
+`editorial-rules.md` in your Web XP install is the prose styleguide. Read it on demand and apply it to covered prose (its Scope lists what counts), including prose you draft for the user to use (e.g. "you can explain the code like this: …").
+
 ## Before every commit
 
 1. Run `bash ~/.web-xp/bin/pre-commit-check.sh` — catches mechanical violations.
 2. Review the diff against Patterns and Fail-Safe in `code-guidelines.md` from your Web XP install.
+3. Verify covered prose in the diff against the ER.
 
 ## Claude Code
 

--- a/adapters/codex/CODEX.example.md
+++ b/adapters/codex/CODEX.example.md
@@ -12,10 +12,15 @@ If the task involves JS, HTML, or CSS, read `code-guidelines.md` and `code-philo
 
 Apply the standard to the new code you write for the user's request. Do not refactor unrelated existing code unless the user asks. If you notice pre-existing Web XP violations outside the requested scope, ask whether to fix them now, list them, or leave them.
 
+## Editorial Rules (ER)
+
+`editorial-rules.md` in your Web XP install is the prose styleguide. Read it on demand and apply it to covered prose (its Scope lists what counts), including prose you draft for the user to use (e.g. "you can explain the code like this: …").
+
 ## Before every commit
 
 1. Run `bash ~/.web-xp/bin/pre-commit-check.sh` — catches mechanical violations.
 2. Review the diff against Patterns and Fail-Safe in `code-guidelines.md` from your Web XP install.
+3. Verify covered prose in the diff against the ER.
 ## Codex skill invocation
 
 Use installed Web XP skills by name, for example `web-xp`, `web-xp-check`, `web-xp-review`, and `web-xp-on`.

--- a/adapters/shared-base/AGENT.md
+++ b/adapters/shared-base/AGENT.md
@@ -10,7 +10,12 @@ If the task involves JS, HTML, or CSS, read `code-guidelines.md` and `code-philo
 
 Apply the standard to the new code you write for the user's request. Do not refactor unrelated existing code unless the user asks. If you notice pre-existing Web XP violations outside the requested scope, ask whether to fix them now, list them, or leave them.
 
+## Editorial Rules (ER)
+
+`editorial-rules.md` in your Web XP install is the prose styleguide. Read it on demand and apply it to covered prose (its Scope lists what counts), including prose you draft for the user to use (e.g. "you can explain the code like this: …").
+
 ## Before every commit
 
 1. Run `bash ~/.web-xp/bin/pre-commit-check.sh` — catches mechanical violations.
 2. Review the diff against Patterns and Fail-Safe in `code-guidelines.md` from your Web XP install.
+3. Verify covered prose in the diff against the ER.

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -17,6 +17,7 @@ CODEX_SKILLS_DEST="${HOME}/.agents/skills"
 STANDARDS_FILES=(
   "code-guidelines.md"
   "code-philosophy.md"
+  "editorial-rules.md"
 )
 PRECOMMIT_SRC="${WEB_XP_DIR}/bin/pre-commit-check.sh"
 

--- a/code-guidelines.md
+++ b/code-guidelines.md
@@ -904,6 +904,7 @@ This rule pairs with [Template and cloneNode](#template-and-clonenode): the per-
 Comments are a failure of the code to express itself. When one is necessary, it should justify its existence.
 
 - Comments explain *why*, not *what*. If the comment restates the code, delete it.
+- Comment prose follows the Editorial Rules (ER) in `editorial-rules.md`. Read them on demand when a comment needs more than a line.
 - Avoid comments likely to become obsolete. A comment that drifts from the code it describes is worse than no comment.
 - No decorative banner or landmark comments (`═══`, `───`, `****`, `/* ── Section ── */`). Use code structure — function names, module boundaries, blank lines — to communicate organization.
 - Avoid file header comments, except for necessary information that cannot be placed more locally.

--- a/editorial-rules.md
+++ b/editorial-rules.md
@@ -1,4 +1,4 @@
-# Editorial Rules
+# Editorial Rules (ER)
 
 Editorial rules for doctrine and repository artifacts in Web XP.
 
@@ -6,9 +6,9 @@ Editorial rules for doctrine and repository artifacts in Web XP.
 
 ## Scope
 
-Doctrine and repository artifacts:
+**Covered prose** — the doctrine and repository prose these rules govern:
 
-- drafts
+- drafts, including prose drafted for the user to use (e.g. a suggested explanation of the code)
 - issues
 - issue comments
 - contributor docs
@@ -37,14 +37,25 @@ Each rule below states:
 ## Principles
 
 - **Technical Standard:** Every word performs a function. Maximize information per syllable.
-- **Concise:** Omit restatement, summary lines, and negative constraints. Code over prose.
+- **Concise:** Omit restatement, summary lines, and this-not-that framing. Code over prose. Say more with less. 
 - **Direct:** Use imperative mood and active voice. Name APIs and elements exactly. No paraphrasing.
 - **Accurate:** Use terms as defined by the authorities in **Authoritative References**.
+- **Code First:** Document clear and coherent code. If the code should be adjusted for clarification, do that first.
 - **Sound:** Accessible Precision — balance:
   - Technical Accuracy (exactness)
   - Completeness (edge cases)
   - Human accessibility (readability and utility)
 - **Laconic:** Avoid globals. Scope locally.
+
+---
+
+## Application (normative)
+
+Before sharing a draft, review it against these rules and revise. Cut filler. Read, write, review, revise, repeat — and think.
+
+On revision, when applying feedback — any correction or new information — ask whether it matches the paragraph's topic. Do not cram it into the paragraph if that would reduce cohesion or comprehensibility; find the section where it belongs and add it there, or create one if none exists.
+
+Enforce normative rules yourself. Do not pass known violations to the reviewer for approval. Applying `must`-level rules is mechanical, like `a === b`, and needs no sign-off. Accept and auto-accept will pass mechanical violations through, so the author is the only check. Reserve the reviewer for what judgment decides: clarity, coherence, and the patterns marked Judgment.
 
 ---
 
@@ -89,7 +100,7 @@ Where authorities conflict, name the choice and the reason in the relevant rule 
 
 ## Instructional Leakage (judgment)
 
-Instructional Leakage is meta content about the work, written into an artifact whose job is to *be* the work, not describe it.
+Instructional Leakage (IL) is meta content about the work, written into artifacts whose job is to *be* the work, not describe it.
 
 **Categories** include but are not limited to:
 
@@ -171,7 +182,7 @@ Omit acceptance criteria that describe prose formatting instead of delivery.
 
 ### Rule Location vs. Governed Artifact
 
-Do not conflate the file where a rule lives with the artifact it governs.
+Do not conflate the file that states a rule with the artifact it governs.
 
 > Reject: The priming applies to `CODEX.md`.
 >
@@ -198,10 +209,34 @@ Reference sections by name. Do not paraphrase or duplicate their content.
 | surface | file, API, DOM, command, UI, adapter path |
 | seam | module boundary, API boundary, extraction point |
 | framing | rule boundary, issue scope, claim |
+| ecosystem | use proper terminology; this software; nothing ecological about it | 
 
 > Reject: Source data shaped as `[{ id, ... }]`, often paired with `.find(...)`.
 >
 > Use: Trigger: keyed lookup over array records that contain `id`.
+
+---
+
+## Lives (normative)
+
+Nothing lives. Code, files, content, and logic do not "live" anywhere.
+
+**Pattern:** `lives` / `lives in` (or other life verbs) stating where code, a file, or content is located.
+
+**Action:** flag; replace with one of:
+
+- the mechanism — name what the code does and the API that does it
+- an explanation — when "lives" leads into a code block or sits where the code should be explained, explain the code
+- a pointer — `see [document/section]`
+- a plain location verb — `is in`, `is defined in`, `the appendix covers`
+
+> Reject: The transition code lives in `startTransition`.
+>
+> Use: To smooth the transition, call `startTransition`.
+
+> Reject: The per-feature deep dives live in the appendix.
+>
+> Use: See the appendix for per-feature deep dives.
 
 ---
 
@@ -332,12 +367,19 @@ Empty intensifiers add emphasis without information.
 
 ## Prose Mechanics (normative)
 
-Doctrine and rule prose uses:
+Prose uses two registers. Decide per sentence by subject and verb:
 
-- imperative mood
+- **Normative** — instructs. Implied second-person subject, command verb: "Use `Array.isArray`", "Avoid globals". Imperative mood.
+- **Descriptive** — describes the system. Third-person subject (the code, the handler, the browser), finite verb stating behavior: "The handler reads `event.target`", "The list reorders only on drop". Declarative, present tense, third person; no second person.
+
+**Test:** subjectless base-form verb ("Use `Array.isArray`") → normative; third-person subject + finite verb ("The handler reads `event.target`") → descriptive.
+
+Both registers use:
+
 - active voice
-- present tense for runtime behavior
-- no first person; second person only in contributor instructions
+- present tense
+- exact technical nouns
+- no first person; second person only in normative contributor instructions
 - punctuation outside quotation marks unless part of the literal string (Web XP follows WHATWG, Wikipedia, and Linux-kernel style here, departing from the Google Developer Documentation Style Guide)
 
 **Pattern:** prose that violates any of the above.
@@ -363,3 +405,68 @@ Doctrine and rule prose uses:
 > Reject: Set the role to "button."
 >
 > Use: Set the role to "button".
+
+
+## Quantifier Scope (normative)
+
+Match each determiner to its claim's scope.
+
+Claims about every member of a class take the bare plural ("Nouns name things") or a distributive universal (`each`/`every`/`any`). The singular indefinite article does not state class claims.
+
+**Pattern:** singular determiner — emphatic (`a single`, `one`), specific (`the X`), or generic (`a`/`an`) — where the claim it modifies is universal.
+
+**Action:** flag; rewrite as a bare plural or a distributive universal.
+
+**Test:** if the claim is universal and "which one?" reads as a sensible question, the determiner is too specific.
+
+> Reject: A single artifact carries both registers.
+>
+> Use: Documents carry both registers.
+
+
+## Slop, Codeslop & Gobbledygook
+
+Agents typically begin with a paragraph label offset by a colon where a topic sentence would go. Example: 
+
+"Billy likes sports: he runs, plays basketball, and swims"
+
+Avoid this pattern.
+
+### Coherence (judgment)
+
+Each paragraph leads with its point, then develops it. Two failures break it — subject-shifting and trailing off.
+
+#### Subject-shifting
+
+**Pattern:** paragraph that conflates a second subject into the point it states.
+
+**Action:** flag; move the second subject to its own paragraph.
+
+> Reject: `getBoundingClientRect()` returns zeros on elements with `display: none`, and the panel also caches its scroll position.
+>
+> Use: `getBoundingClientRect()` returns zeros on elements with `display: none`. Measure after they are shown.
+
+#### Trailing off
+
+**Pattern:** paragraph that continues past its point, ending on subordinate or filler material.
+
+**Action:** flag; cut the trailing material; close on the sentence that completes the point.
+
+> Reject: `getBoundingClientRect()` returns zeros on elements with `display: none`. This is one of several rendering quirks worth keeping in mind.
+>
+> Use: `getBoundingClientRect()` returns zeros on elements with `display: none`. Positions read before they are shown are stale.
+
+### Codeslop
+AI code slop is AI-generated code that borrows framework paradigms and terms (noun, verb, metaphor), and manifests in code, comments, and communications.
+
+| Reject | Use |
+|---|---|
+| `routes` (events) | `handles`, `dispatches` |
+| `mounts` | `appends`, `inserts` |
+| `hydrate` | builds from data |
+| `lifecycle` | construction; one-time init |
+| `primitive` | the class (identifier + construct) |
+| `domain layer` | the module; the file |
+| `data model` | the class; the decorator |
+| `row` (for an `<li>`) | `item` |
+

--- a/editorial-rules.md
+++ b/editorial-rules.md
@@ -257,6 +257,7 @@ RFC 2119 ALL-CAPS forms (MUST, SHOULD, MAY) are reserved for tight agent operati
 | material accuracy | domain-accurate naming |
 | materially accurate | named with domain terms |
 | narrower, broader, simpler, cleaner, stricter, tighter | name the axis and the property tested |
+| single source of truth | name the variable, its writer, and its readers |
 
 > Reject: `instanceof` is narrower.
 >

--- a/test/unit/install.bats
+++ b/test/unit/install.bats
@@ -25,6 +25,16 @@ teardown() {
   [ ! -e "$TMP_HOME/.claude/skills/web-xp-apply" ]
 }
 
+@test "installs standards files including editorial-rules" {
+  run env HOME="$TMP_HOME" WEB_XP_MANIFEST_PATH="$MANIFEST_PATH" bash "$INSTALL_SCRIPT"
+  [ "$status" -eq 0 ]
+
+  assert_file_exists "$TMP_HOME/.claude/skills/code-guidelines.md"
+  assert_file_exists "$TMP_HOME/.claude/skills/code-philosophy.md"
+  assert_file_exists "$TMP_HOME/.claude/skills/editorial-rules.md"
+  grep -Fx "$TMP_HOME/.claude/skills/editorial-rules.md" "$MANIFEST_PATH"
+}
+
 @test "replaces stale Web XP files on reinstall" {
   # Pre-seed a stale standards file and a stale skill dir
   mkdir -p "$TMP_HOME/.claude/skills/web-xp-check"


### PR DESCRIPTION
Publishes the Editorial Rules (ER) and wires them into the contract for on-demand reading.

## Changes

- `editorial-rules.md` gains the (ER) title, defines covered prose in its Scope, and adds the Coherence rule (Subject-shifting, Trailing off) plus the On-revision rule.
- `adapters/shared-base/AGENT.md` adds the ER pointer — read on demand for covered prose — and a commit-time verify step.
- `code-guidelines.md` routes comment prose to the ER.
- `bin/install.sh` ships `editorial-rules.md` with the standards, and `install.bats` asserts it.
- The build regenerates `CLAUDE.example.md` and `CODEX.example.md`.

## Issues

- #65 (closed) — the editorial gate, wired at the source. Contributor-context contracts pick it up through the AGENTS.md migration (#67).
- Refs #75 — lands the `code-guidelines.md` line; the pre-commit grep remains.
