### PR TITLE
contract: link the Editorial Gate from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ On completion (work landed and committed), close the issue and delete temporary 
 
 **Duplicate avoidance.** Before filing an issue or posting a comment, search the tracker for existing duplicates. Issues, comments, files — same rule: search before adding. If a duplicate is found, reference the existing artifact rather than creating another.
 
+## Editorial Gate
+
+`editorial-rules.md` governs covered prose — its Scope lists the covered artifacts (this contract included), its Application states the passes. Apply it while drafting or revising a covered artifact, and before publishing one.
+
 ## Contextual Gatekeeper
 
 Treat corrective commentary as functional input. Use it to transform the

--- a/test/unit/contributor-contracts.bats
+++ b/test/unit/contributor-contracts.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+@test "AGENTS.md references the Editorial Gate" {
+  grep -Fq '## Editorial Gate' "$REPO_ROOT/AGENTS.md"
+  grep -Fq 'editorial-rules.md' "$REPO_ROOT/AGENTS.md"
+}
+
+@test "AGENTS.md links the gate rather than inlining it (Section Restatement)" {
+  ! grep -Fq 'Three passes:' "$REPO_ROOT/AGENTS.md"
+}


### PR DESCRIPTION
Wires the Editorial Gate into the contributor contract `AGENTS.md` (#65).

`AGENTS.md` references `editorial-rules.md` by section name — its **Scope** (covered artifacts) and **Application** (the passes) — instead of inlining the gate block. Inlining would duplicate content the ER already holds and break the ER's own **Section Restatement** rule. Two triggers: Drafting (on-demand read) and Pre-publish gate; Priming dropped per the AC-update comment.

A unit test (`test/unit/contributor-contracts.bats`) asserts `AGENTS.md` references the gate and does not inline it. Unit suite: 34/34.

Closes #65.
